### PR TITLE
Updating peerDependancy to 0.8 for winston

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "sinon": "~1.7.3"
   },
   "peerDependencies": {
-    "winston": "~0.7"
+    "winston": "~0.8"
   },
   "main": "./lib/winston-hipchat",
   "scripts": {


### PR DESCRIPTION
Updated the package.json to have peerDependencies as winstons most up to date version.
